### PR TITLE
Add optional config to api, to make hmvc easier.

### DIFF
--- a/lib/schemas/api.js
+++ b/lib/schemas/api.js
@@ -4,6 +4,6 @@ module.exports = joi.object().keys({
   controllers: joi.object().required(),
   models: joi.object().required(),
   policies: joi.object().required(),
-  services: joi.object().required()
+  services: joi.object().required(),
+  config: joi.object().optional()
 })
-


### PR DESCRIPTION
As mentioned in  trailsjs/generator-trails#12, this allows us to move specific config values into the api model, which would make hmvc easier (as we can store routes, policy config etc) in feature folders.
