### PR TITLE
Fix misleading typo in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ npm install --save trailpack-core
 The core trailpack should always be loaded in your trailpack config.
 
 ```js
-// config/trailpack.js
+// config/main.js
 module.exports = {
   // ...
   packs: [


### PR DESCRIPTION
The readme file indicates that the trailpack configuration is done in the config/trailpack.js but it is in the config/main.js 
